### PR TITLE
Remove invalid macro from `pvPortRealloc`.

### DIFF
--- a/FreeRTOS-Classic/FreeRTOS/Source/portable/MemMang/heap_4.c
+++ b/FreeRTOS-Classic/FreeRTOS/Source/portable/MemMang/heap_4.c
@@ -318,7 +318,7 @@ void *pvReturn = NULL;
         if(pxLink->xBlockSize & xBlockAllocatedBit)
         {
             uint32_t blockSize = (pxLink->xBlockSize & ~xBlockAllocatedBit);
-            blockSize -= (xHeapStructSize + HEAP_CHECK_SIZE);
+            blockSize -= xHeapStructSize;
             pvReturn = pvPortMalloc(xWantedSize);
             if(pvReturn)
             {

--- a/FreeRTOS-Classic/FreeRTOS/Source/portable/MemMang/heap_5.c
+++ b/FreeRTOS-Classic/FreeRTOS/Source/portable/MemMang/heap_5.c
@@ -327,7 +327,7 @@ void *pvReturn = NULL;
         if(pxLink->xBlockSize & xBlockAllocatedBit)
         {
             uint32_t blockSize = (pxLink->xBlockSize & ~xBlockAllocatedBit);
-            blockSize -= (uxHeapStructSize + HEAP_CHECK_SIZE);
+            blockSize -= uxHeapStructSize;
             pvReturn = pvPortMalloc(xWantedSize);
             if(pvReturn)
             {


### PR DESCRIPTION
Fixes #4.